### PR TITLE
Fix Contact model imports

### DIFF
--- a/clio_clients/models/contact.py
+++ b/clio_clients/models/contact.py
@@ -3,9 +3,20 @@
 
 from __future__ import annotations
 
+from typing import List, Optional
+
+from clio_clients.models.type.type10 import Type10
+
 from clio_clients.models.contactbase import ContactBase
 from clio_clients.models.contactshow import ContactShow
 
 
 class Contact(ContactBase, ContactShow):
+    """Combined Contact model with nested relationships."""
+
     pass
+
+
+# Rebuild models to resolve forward references
+Contact.model_rebuild()
+ContactShow.model_rebuild()

--- a/clio_clients/models/contactshow.py
+++ b/clio_clients/models/contactshow.py
@@ -3,8 +3,17 @@
 
 from __future__ import annotations
 
-from pydantic import BaseModel
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from pydantic import BaseModel, Field
+
+if TYPE_CHECKING:  # pragma: no cover - used for type checkers only
+    from .contact import Contact
 
 
 class ContactShow(BaseModel):
-    data: Data
+    """Response wrapper containing a Contact."""
+
+    data: "Contact" = Field(..., description="Contact")


### PR DESCRIPTION
## Summary
- resolve forward references for Contact models
- ensure ContactShow's data field references Contact

## Testing
- `pytest clio_client/test/test_contact_show.py -q` *(fails: ModuleNotFoundError: No module named 'clio_client')*

------
https://chatgpt.com/codex/tasks/task_e_684886d586e48331af40c8654939c6ea